### PR TITLE
Fix format of `architectures` metadata field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,4 +5,4 @@ maintainer=M C Nelson
 sentence=Fix for the official SPI, true 16 bit transfers and loop-friendly repeated 16 bi transfers
 paragraph=
 category=Communications
-architectures=architectures=renesas_uno
+architectures=renesas_uno


### PR DESCRIPTION
The library.properties metadata file uses a `<key>=<value>` data format. Previously, the `architectures field had an invalid `<key>=<key>=<value>` format, which would cause it to not correctly define the compatible architectures for the Arduino development tools.